### PR TITLE
Fix for IOS events not firing in the latest version

### DIFF
--- a/src/template/index.ts
+++ b/src/template/index.ts
@@ -39,7 +39,7 @@ const addListeners = () => {
     video.addEventListener('seeking', (e) => sendEvent('seeking', e));
     video.addEventListener('stalled', (e) => sendEvent('stalled', e));
     video.addEventListener('suspend', (e) => sendEvent('suspend', e));
-    video.addEventListener('timeupdate', (e) => sendEvent('timeupdate', e));
+//     video.addEventListener('timeupdate', (e) => sendEvent('timeupdate', e));
     video.addEventListener('volumechange', (e) => sendEvent('volumechange', e));
     video.addEventListener('waiting', (e) => sendEvent('waiting', e));
   }
@@ -55,5 +55,5 @@ const addListeners = () => {
   },300);
 };
 
-setTimeout(addListeners(), 1000);
+setTimeout(function(){addListeners()}, 1000);
 `


### PR DESCRIPTION
This resolves the issue of events not firing on IOS.  It was due to a small syntax issue.
This also removes the extra event listener for timeupdate. The correct event listener for timeupdate is above and is far more involved.