### PR TITLE
Remove unused console.log

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,6 @@ export const Vimeo: React.FC<LayoutProps> = ({
       ref={webRef as any}
       onMessage={onBridgeMessage}
       scrollEnabled={false}
-      onNavigationStateChange={(a) => console.log(a?.url)}
       injectedJavaScript={template(url)}
       {...otherProps}
     />


### PR DESCRIPTION
The removed line was logging the video URL to the console every time the video was getting loaded. So removed it.