### PR TITLE
Fix/autoplay

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,8 @@ export const Vimeo: React.FC<LayoutProps> = ({
     ? `https://player.vimeo.com/video/${videoId}?${params}`
     : `https://player.vimeo.com/video/${videoId}`
 
+  const autoPlay = params?.includes('autoplay=1')
+
   const handlers: any = {}
 
   const registerHandlers = useCallback(() => {
@@ -41,13 +43,14 @@ export const Vimeo: React.FC<LayoutProps> = ({
   return (
     <WebView
       allowsFullscreenVideo={true}
-      source={{ uri: url,headers: { Referer: reference }, }}
+      source={{ uri: url, headers: { Referer: reference } }}
       javaScriptEnabled={true}
       ref={webRef as any}
       onMessage={onBridgeMessage}
       scrollEnabled={false}
       onNavigationStateChange={(a) => console.log(a?.url)}
       injectedJavaScript={template(url)}
+      mediaPlaybackRequiresUserAction={autoPlay}
       {...otherProps}
     />
   )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,7 @@ export const Vimeo: React.FC<LayoutProps> = ({
       scrollEnabled={false}
       onNavigationStateChange={(a) => console.log(a?.url)}
       injectedJavaScript={template(url)}
-      mediaPlaybackRequiresUserAction={autoPlay}
+      mediaPlaybackRequiresUserAction={!autoPlay}
       {...otherProps}
     />
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,13 +2,7 @@ import { WebViewProps } from 'react-native-webview'
 
 export type CallbackType = (data?: any) => void
 export interface LayoutProps extends WebViewProps {
-  loop?: boolean
-  autoPlay?: boolean
-  controls?: boolean
-  speed?: boolean
-  time?: `${number}h${number}m${number}s`
   handlers?: { [key: string]: any }
-  getVimeoPlayer?: any
   videoId: string
   params?: string
   reference?: string


### PR DESCRIPTION
autoplay woesn't working for android webview because mediaPlaybackRequiresUserAction is true(which means user is forced to tab before playing media).

so i managed to change it to depend on autoplay param.

and additionally removed some types that aren't supported anymore